### PR TITLE
Drop console formatting rebased

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,72 @@
+name: CI
+on:
+  - push
+  - pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc:
+          - "8.0"
+          - "8.2"
+          - "8.4"
+          - "8.6"
+          - "8.8"
+          - "8.10"
+          - "9.0"
+          - "9.2"
+          - "9.4"
+        haddock: [false]
+        include:
+        - os: ubuntu-latest
+          ghc: "9.6"
+          haddock: [true]
+        - os: macOS-latest
+          ghc: "9.6"
+          haddock: [false]
+        - os: windows-latest
+          ghc: "9.6"
+          haddock: [false]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
+      id: setup-haskell-cabal
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - uses: actions/cache@v2
+      name: Cache cabal stuff
+      with:
+        path: |
+          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}
+    - name: Cabal version
+      run: |
+        cabal --version
+    - name: Unpack
+      run: |
+        cabal sdist --ignore-project --output-directory ..
+        cd ..
+        cabal get tasty-ant-xml-*.tar.gz
+    - name: Build
+      run: |
+        cd ../tasty-ant-xml-*/
+        cabal build all
+    - name: Haddock
+      if: ${{ matrix.haddock }}
+      run: |
+        cd ../tasty-ant-xml-*/
+        cabal haddock all
+    - name: Cabal check
+      run: |
+        cd ../tasty-ant-xml-*/
+        cabal check

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 1.1.9
+
+## Other changes
+
+* Support `tasty-1.5`. Thanks to @sergv (PR #34).
+
 # 1.1.8
 
 ## Other Changes

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -1,5 +1,5 @@
 name: tasty-ant-xml
-version: 1.1.8
+version: 1.1.9
 synopsis: Render tasty output to XML for Jenkins
 description: A tasty ingredient to output test results in XML, using the Ant schema. This XML can be consumed by the Jenkins continuous integration framework.
 homepage: http://github.com/ocharles/tasty-ant-xml

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -23,7 +23,7 @@ library
     mtl >= 2.1.2,
     stm >= 2.4.2,
     tagged >= 0.7,
-    tasty >= 1.4 && < 1.5,
+    tasty >= 1.4 && < 1.6,
     transformers >= 0.3.0.0,
     directory >= 1.2.3.0,
     filepath >= 1.0.0,


### PR DESCRIPTION
Rebased on [upstream](https://github.com/ocharles/tasty-ant-xml) `master` to gain support for Tasty 1.5. This is useful, because Tasty 1.5 is delivered by default in nixpkgs' `unstable` now.